### PR TITLE
correct literal index in clause copy (fixes issue #2)

### DIFF
--- a/proplog_dpll.js
+++ b/proplog_dpll.js
@@ -497,7 +497,7 @@ function simplify_clause_list(clauses,varvals,occvars,posbuckets,negbuckets,deri
       nc=new Int32Array(nlen);
       nc[0]=clause[0];
       nc[1]=clause[1];
-      k=0;
+      k=2;
       for(j=2;j<clause.length;j++) {
         if (clause[j]===0) continue;
         nc[k]=clause[j];


### PR DESCRIPTION
Minimal formula to reproduce:

```
(-p V -k V k) & (-p V -k V -p)
```

NOTE: this patch does not fix the minified code. `proplog_min.js` needs to be regenerated after merging the patch.